### PR TITLE
Heroku is no longer free of use - domain changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ papers published while working with [AFRL](https://www.afrl.af.mil/).
   </div>
   <br><br><br><br><br><br><br><br><br>
   <br>
-  <img src="https://activity-graph.herokuapp.com/graph?username=akaszynski&count_private=true&theme=react-dark&bg_color=20232a&hide_border=true" width="100%"/>
+  <img src="https://github-readme-activity-graph.cyclic.app/graph?username=akaszynski&count_private=true&theme=react-dark&bg_color=20232a&hide_border=true" width="100%"/>
 </p>
 
 


### PR DESCRIPTION
Also happened on my profile. See https://github.com/Ashutosh00710/github-readme-activity-graph#%EF%B8%8F-notice-deployment-moved-%EF%B8%8F